### PR TITLE
Keys and Values returning as IList

### DIFF
--- a/SoftCircuits.OrderedDictionary/OrderedDictionary.cs
+++ b/SoftCircuits.OrderedDictionary/OrderedDictionary.cs
@@ -255,12 +255,14 @@ namespace SoftCircuits.Collections
         /// <summary>
         /// Returns an ordered list of the keys in the collection.
         /// </summary>
-        public ICollection<TKey> Keys => new List<TKey>(Items.Select(i => i.Key));
+        public IList<TKey> Keys => new List<TKey>(Items.Select(i => i.Key));
+        ICollection<TKey> IDictionary<TKey, TValue>.Keys => Keys;
 
         /// <summary>
         /// Returns an ordered list of the values in the collection.
         /// </summary>
-        public ICollection<TValue> Values => new List<TValue>(Items.Select(i => i.Value));
+        public IList<TValue> Values => new List<TValue>(Items.Select(i => i.Value));
+        ICollection<TValue> IDictionary<TKey, TValue>.Values => Values;
 
         /// <summary>
         /// Always returns false.


### PR DESCRIPTION
As discussed in https://github.com/SoftCircuits/OrderedDictionary/issues/4
The compatibility with IDictionary is preserved through [Explicit Interface Implementation](https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/interfaces/explicit-interface-implementation).
Seeing as IList is implementing ICollection anyway, "hiding" it over the ICollection variant shouldn't break any code.